### PR TITLE
hide image and video upload, fix email modal header

### DIFF
--- a/src/components/Activities/components/Email/components/Header/EmailPageHeader.js
+++ b/src/components/Activities/components/Email/components/Header/EmailPageHeader.js
@@ -17,8 +17,8 @@ const EmailPageHeader = (props) => {
     const createModal = (value) => (<EmailModal
                                           modalController={value}
                                           handleCreateNote={props.handleCreateNote}/>);   */
-  const logEmailModal = new Modal('Note', 'Note', LogEmailModal);
-  const createEmailModal = new Modal('Note', 'Note', EmailModal);
+  const logEmailModal = new Modal('Email', 'Email', LogEmailModal);
+  const createEmailModal = new Modal('Email', 'Email', EmailModal);
 
   return (
     <ModalContext.Consumer>

--- a/src/components/Style/Editor/Editor.js
+++ b/src/components/Style/Editor/Editor.js
@@ -46,7 +46,7 @@ Editor.modules = {
     ['clean'],
     [{ 'list': 'ordered' }, { 'list': 'bullet' },
       { 'indent': '-1' }, { 'indent': '+1' }],
-    ['link', 'image', 'video'],
+    ['link'],
   ],
   clipboard: {
     // toggle to add extra line breaks when pasting HTML:
@@ -58,7 +58,7 @@ Editor.formats = [
   'header', 'font', 'size',
   'bold', 'italic', 'underline', 'strike', 'blockquote',
   'list', 'bullet', 'indent',
-  'link', 'image', 'video',
+  'link', 
 ];
 
 export default Editor;


### PR DESCRIPTION
hide image and video upload
fix email modal header
<img width="1061" alt="Screen Shot 2020-11-05 at 1 51 11 pm" src="https://user-images.githubusercontent.com/11739209/98191828-230f4900-1f6e-11eb-8735-f3cc89effd3a.png">
